### PR TITLE
Add VITE_API_URL environment variable to build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
 
     - name: Build project
       run: npm run build
+      env:
+        VITE_API_URL: ${{ secrets.VITE_API_URL }}
       working-directory: ./PGA-PI
 
     # Versionamento Semântico


### PR DESCRIPTION
Include the VITE_API_URL environment variable in the build process to ensure the application can access the necessary API endpoint during the build.