### PR TITLE
Improve keyboard shortcuts and focus visibility for accessibility

### DIFF
--- a/PGA-PI/src/components/accessibility/KeyboardShortcuts.tsx
+++ b/PGA-PI/src/components/accessibility/KeyboardShortcuts.tsx
@@ -127,18 +127,17 @@ export const KeyboardShortcuts = ({ onToggleAccessibilityMenu }: KeyboardShortcu
 // Componente para mostrar lista de atalhos
 export const AccessibilityHelp = () => {
   return (
-    <div className="accessibility-help bg-gray-50 p-4 rounded-lg text-sm text-gray-700">
-      <h4 className="font-semibold mb-2">Atalhos de Teclado</h4>
-      <ul className="space-y-1">
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + A</kbd> - Abrir menu de acessibilidade</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + +</kbd> - Aumentar fonte</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + -</kbd> - Diminuir fonte</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + 0</kbd> - Restaurar fonte padrão</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + C</kbd> - Alternar alto contraste</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + D</kbd> - Alternar tema claro/escuro</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Alt + M</kbd> - Alternar redução de movimento</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Tab</kbd> - Navegar pelos elementos</li>
-        <li><kbd className="bg-gray-200 px-2 py-1 rounded">Esc</kbd> - Fechar menus/modais</li>
+    <div className="accessibility-help text-sm text-gray-700 dark:text-gray-300">
+      <ul className="space-y-2">
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + A</kbd><span>Abrir acessibilidade</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + +</kbd><span>Aumentar fonte</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + -</kbd><span>Diminuir fonte</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + 0</kbd><span>Restaurar fonte</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + C</kbd><span>Alto contraste</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + D</kbd><span>Tema claro/escuro</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Alt + M</kbd><span>Reduzir animações</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Tab</kbd><span>Navegar elementos</span></li>
+        <li className="flex items-center gap-3"><kbd className="bg-gray-100 dark:bg-[#21262d] border border-gray-300 dark:border-[#30363d] px-2 py-0.5 rounded text-xs font-mono min-w-[80px] text-center">Esc</kbd><span>Fechar modal</span></li>
       </ul>
     </div>
   );

--- a/PGA-PI/src/components/layout/Header.tsx
+++ b/PGA-PI/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useAccessibility } from "@/hooks/useAccessibility";
-import { Menu, ChevronLeft, ChevronRight, Settings, User, LogOut, Info, Plus, Minus, Contrast, Moon, Sun, Zap, ZapOff, Volume2, VolumeX, Monitor, Type, Palette, Activity } from "lucide-react";
+import { Menu, ChevronLeft, ChevronRight, Settings, User, LogOut, Info, Plus, Minus, Contrast, Moon, Sun, Zap, ZapOff, Volume2, VolumeX, Monitor, Type, Palette, Activity, HelpCircle, XCircle } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
@@ -39,6 +39,7 @@ export const Header: React.FC<HeaderProps> = ({ toggleSidebar, isMobile, isExpan
   // Estados para controlar a exibição dos modais
   const [isAccessibilityModalOpen, setIsAccessibilityModalOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [showShortcuts, setShowShortcuts] = useState(false);
 
   
   // Estados para controlar o gesto de swipe
@@ -296,11 +297,48 @@ export const Header: React.FC<HeaderProps> = ({ toggleSidebar, isMobile, isExpan
         isOpen={isAccessibilityModalOpen}
         onClose={() => {
           setIsAccessibilityModalOpen(false);
+          setShowShortcuts(false);
           announceToScreenReader("Configurações de acessibilidade fechadas");
         }}
         title="Acessibilidade"
         className="max-w-[95%] md:max-w-lg mx-auto"
+        sidePanel={
+          <div
+            className={`w-72 bg-white dark:bg-[#1c2130] border border-gray-200 dark:border-[#30363d] rounded-2xl shadow-2xl transition-all duration-300 ${
+              showShortcuts ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4 pointer-events-none'
+            }`}
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-[#30363d]">
+              <span className="text-sm font-semibold text-gray-700 dark:text-gray-200">Atalhos de Teclado</span>
+              <button
+                onClick={() => setShowShortcuts(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                aria-label="Fechar painel de atalhos"
+              >
+                <XCircle className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="p-4">
+              <AccessibilityHelp />
+            </div>
+          </div>
+        }
       >
+        <div className="relative">
+        {/* Botão ? no canto superior direito do conteúdo */}
+        <button
+          onClick={() => setShowShortcuts(v => !v)}
+          className={`absolute top-0 right-0 flex items-center justify-center w-7 h-7 rounded-full border transition-colors z-10 ${
+            showShortcuts
+              ? 'border-[#ae0f0a] text-[#ae0f0a]'
+              : 'border-gray-300 dark:border-[#30363d] text-gray-400 hover:text-[#ae0f0a] hover:border-[#ae0f0a]'
+          }`}
+          aria-label="Ver atalhos de teclado"
+          aria-pressed={showShortcuts}
+          title="Atalhos de teclado"
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
         <div className="space-y-5">
 
           {/* ── Tamanho da Fonte ───────────────────────────────── */}
@@ -495,6 +533,7 @@ export const Header: React.FC<HeaderProps> = ({ toggleSidebar, isMobile, isExpan
               Salvar e Fechar
             </Button>
           </div>
+        </div>
         </div>
       </Modal>
 

--- a/PGA-PI/src/components/ui/modal.tsx
+++ b/PGA-PI/src/components/ui/modal.tsx
@@ -7,6 +7,7 @@ interface ModalProps {
   title: string;
   children: ReactNode;
   className?: string;
+  sidePanel?: ReactNode;
 }
 
 export const Modal = ({
@@ -15,6 +16,7 @@ export const Modal = ({
   title,
   children,
   className,
+  sidePanel,
 }: ModalProps): JSX.Element | null => {
   if (!isOpen) return null;
 
@@ -26,18 +28,20 @@ export const Modal = ({
         onClick={onClose}
       />
 
-      {/* Modal Content */}
+      {/* Wrapper relativo para posicionamento do sidePanel fora do overflow */}
       <div
-        className={`relative z-50 w-full mx-auto md:rounded-[21px] rounded-t-[21px] shadow-lg overflow-hidden mobile-modal bg-white dark:bg-[#1c2130] ${
-          className || ""
-        }`}
-        style={{
-          boxSizing: "border-box",
-          maxWidth: "min(100%,720px)",
-          maxHeight: "calc(100vh - 4rem)",
-          overflowY: "auto",
-        }}
+        className={`relative z-50 w-full mx-auto ${className || ""}`}
+        style={{ maxWidth: "min(100%,720px)" }}
       >
+        {/* Modal Content */}
+        <div
+          className="w-full md:rounded-[21px] rounded-t-[21px] shadow-lg overflow-hidden mobile-modal bg-white dark:bg-[#1c2130]"
+          style={{
+            boxSizing: "border-box",
+            maxHeight: "calc(100vh - 4rem)",
+            overflowY: "auto",
+          }}
+        >
         <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-[#30363d] mobile-modal-header">
           <h2 className="font-['Source_Sans_3',Helvetica] text-2xl font-bold text-[#2D3748] dark:text-[#e6edf3]">
             {title}
@@ -54,7 +58,15 @@ export const Modal = ({
         <div className="p-6 rounded-b-[21px] mobile-modal-content bg-white dark:bg-[#1c2130]">
           {children}
         </div>
-      </div>
+        </div>{/* fim modal content */}
+
+        {/* Side panel fora do overflow-hidden */}
+        {sidePanel && (
+          <div className="absolute top-0 left-full ml-3 hidden md:block">
+            {sidePanel}
+          </div>
+        )}
+      </div>{/* fim wrapper */}
     </div>
   );
 };

--- a/PGA-PI/src/styles/accessibility.css
+++ b/PGA-PI/src/styles/accessibility.css
@@ -302,22 +302,22 @@
 }
 
 /* Focus visível para navegação por teclado */
-.accessibility-focus:focus,
-button:focus,
-input:focus,
-select:focus,
-textarea:focus,
-a:focus {
+.accessibility-focus:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible {
   outline: 3px solid #ae0f0a !important;
   outline-offset: 2px !important;
 }
 
-.dark .accessibility-focus:focus,
-.dark button:focus,
-.dark input:focus,
-.dark select:focus,
-.dark textarea:focus,
-.dark a:focus {
+.dark .accessibility-focus:focus-visible,
+.dark button:focus-visible,
+.dark input:focus-visible,
+.dark select:focus-visible,
+.dark textarea:focus-visible,
+.dark a:focus-visible {
   outline: 3px solid var(--dark-accent-hover) !important;
   outline-offset: 2px !important;
 }


### PR DESCRIPTION
This pull request enhances the accessibility modal by adding a dedicated keyboard shortcuts side panel, improves the visual presentation of keyboard shortcuts, and refines focus styles for better accessibility. It also introduces a new prop to the `Modal` component to support the side panel layout.

**Accessibility Modal & Keyboard Shortcuts Improvements:**

* Added a side panel to the accessibility modal for displaying keyboard shortcuts, accessible via a new "?" button in the modal. The side panel is visually distinct and can be toggled open/closed. (`PGA-PI/src/components/layout/Header.tsx`, `PGA-PI/src/components/ui/modal.tsx`) [[1]](diffhunk://#diff-8df35faf235222b9d58bbabb3d390e61dc116f377dec450d2063e429745703b8R42) [[2]](diffhunk://#diff-8df35faf235222b9d58bbabb3d390e61dc116f377dec450d2063e429745703b8R300-R341) [[3]](diffhunk://#diff-8df35faf235222b9d58bbabb3d390e61dc116f377dec450d2063e429745703b8R537) [[4]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R10) [[5]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R19) [[6]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R31-L36) [[7]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R61-R69)
* Improved the visual layout of the keyboard shortcuts list for both light and dark modes, using clearer styles and better alignment for readability. (`PGA-PI/src/components/accessibility/KeyboardShortcuts.tsx`)
* Added new icons (`HelpCircle`, `XCircle`) for toggling and closing the shortcuts panel. (`PGA-PI/src/components/layout/Header.tsx`)

**Accessibility & Focus Styles:**

* Updated focus styles to use `:focus-visible` instead of `:focus`, ensuring visible focus indicators only appear during keyboard navigation, improving accessibility and user experience. (`PGA-PI/src/styles/accessibility.css`)

**Component/Prop Updates:**

* Added a new optional `sidePanel` prop to the `Modal` component to support rendering additional side content, such as the keyboard shortcuts panel, outside the main modal overflow area. (`PGA-PI/src/components/ui/modal.tsx`) [[1]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R10) [[2]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R19) [[3]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R31-L36) [[4]](diffhunk://#diff-fd12304320a8777a636f2d232608c18c0f6e3be2a87acf0a2ff00db7a987d7e1R61-R69)